### PR TITLE
Update NodeJS from 12 to 16 to fix Github Actions deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'Architecture flag. Possible values: x86_64 (default) and aarch64. The latter is available only for M1 self-hosted runners and GraalVM 22.1+'
     default: 'x86_64'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'Architecture flag. Possible values: x86_64 (default) and aarch64. The latter is available only for M1 self-hosted runners and GraalVM 22.1+'
     default: 'x86_64'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Made some tests with it on my actions and experienced no problems - and the warning is gone.