### PR TITLE
Update action to latest graalvm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ steps:
   with:
     # GraalVM version. Default: latest
     graalvm: '22.1.0.1-Final'
-    # Java version. Since GraalVM 22, either java11 or java17, before GraalVM 22, empty. Default: java17
-    jdk: 'java17'
-    # Architecture flag. Available options are 'x86_64' (default) and 'aarch64'. The latter is available only for M1 self-hosted runners since GraalVM 22.1.
+    # Java version. Since GraalVM 22, either java11, java17 or java23. Before GraalVM 22, empty. Default: java23
+    jdk: 'java23'
+    # Architecture flag. Available options are 'x86_64' (default) and 'aarch64'. The latter is available for M1 runners starting GraalVM 22.1.
     arch: 'x86_64'
 - run: java -version
 ```
@@ -28,3 +28,13 @@ steps:
 # License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)
+
+# Developers
+
+To build the action locally, run the following:
+
+```
+nmp install
+npm i -g @vercel/ncc
+ncc build src/setup-graalvm.ts -o dist
+```

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,11 @@ inputs:
     description: 'The GraalVM version built by Gluon, defaults to latest'
     default: 'latest'
   jdk:
-    description: 'The JDK version used to build the GraalVM version. Possible values: java17 (default) or java11, if GraalVM is 22+, else empty'
-    default: 'java17'
+    description: 'The JDK version used to build the GraalVM version. Possible values: java23 (default), java17 or java11, if GraalVM is 22+. For lower, it should be empty'
+    default: 'java23'
   arch:
-    description: 'Architecture flag. Possible values: x86_64 (default) and aarch64. The latter is available only for M1 self-hosted runners and GraalVM 22.1+'
+    description: 'Architecture flag. Possible values: x86_64 (default) and aarch64. The latter is available for M1 runners and GraalVM 22.1+'
     default: 'x86_64'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9497,15 +9497,15 @@ function getGraalVM(graalvm, jdk, arch) {
             let m1 = ``;
             if (jdk == 'java23') {
                 java = `-${jdk}`;
-                m1 = `amd64`;
+                m1 = `-amd64`;
                 if (arch == 'aarch64') {
-                    m1 = `aarch64`;
+                    m1 = `-aarch64`;
                 }
             }
             else if (jdk == 'java17' || jdk == 'java11') {
                 java = `svm-${jdk}`;
                 if (arch == 'aarch64') {
-                    m1 = `m1`;
+                    m1 = `-m1`;
                 }
             }
             else {
@@ -9515,7 +9515,7 @@ function getGraalVM(graalvm, jdk, arch) {
             if (IS_WINDOWS || graalvmShort.startsWith('gluon-22.0') || graalvmShort.startsWith('gluon-21')) {
                 ext = 'zip';
             }
-            const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-${java}-${platform}-${m1}-${graalvmShort}.${ext}`;
+            const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-${java}-${platform}${m1}-${graalvmShort}.${ext}`;
             core.info(`Downloading Gluon's GraalVM from ${downloadPath}`);
             const graalvmFile = yield tc.downloadTool(downloadPath);
             const tempDir = path.join(tempDirectory, `temp_${Math.floor(Math.random() * 2000000000)}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 5183:
+/***/ 5954:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -15,7 +15,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(8091);
+const utils_1 = __nccwpck_require__(6672);
 /**
  * Commands
  *
@@ -87,7 +87,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 2619:
+/***/ 3526:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -109,9 +109,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __nccwpck_require__(5183);
-const file_command_1 = __nccwpck_require__(5939);
-const utils_1 = __nccwpck_require__(8091);
+const command_1 = __nccwpck_require__(5954);
+const file_command_1 = __nccwpck_require__(3298);
+const utils_1 = __nccwpck_require__(6672);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
 /**
@@ -332,7 +332,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 5939:
+/***/ 3298:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -350,7 +350,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(7147));
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(8091);
+const utils_1 = __nccwpck_require__(6672);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -368,7 +368,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 8091:
+/***/ 6672:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -394,7 +394,7 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 341:
+/***/ 4905:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -416,7 +416,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tr = __importStar(__nccwpck_require__(745));
+const tr = __importStar(__nccwpck_require__(479));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -445,7 +445,7 @@ exports.exec = exec;
 
 /***/ }),
 
-/***/ 745:
+/***/ 479:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -471,8 +471,8 @@ const os = __importStar(__nccwpck_require__(2037));
 const events = __importStar(__nccwpck_require__(2361));
 const child = __importStar(__nccwpck_require__(2081));
 const path = __importStar(__nccwpck_require__(1017));
-const io = __importStar(__nccwpck_require__(9006));
-const ioUtil = __importStar(__nccwpck_require__(4436));
+const io = __importStar(__nccwpck_require__(5998));
+const ioUtil = __importStar(__nccwpck_require__(3764));
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -1052,7 +1052,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 1709:
+/***/ 1015:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1060,7 +1060,7 @@ class ExecState extends events.EventEmitter {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const http = __nccwpck_require__(3685);
 const https = __nccwpck_require__(5687);
-const pm = __nccwpck_require__(382);
+const pm = __nccwpck_require__(922);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1479,7 +1479,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(6237);
+                tunnel = __nccwpck_require__(9622);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1595,7 +1595,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 382:
+/***/ 922:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1660,7 +1660,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 4436:
+/***/ 3764:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1862,7 +1862,7 @@ function isUnixExecutable(stats) {
 
 /***/ }),
 
-/***/ 9006:
+/***/ 5998:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1880,7 +1880,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const childProcess = __nccwpck_require__(2081);
 const path = __nccwpck_require__(1017);
 const util_1 = __nccwpck_require__(3837);
-const ioUtil = __nccwpck_require__(4436);
+const ioUtil = __nccwpck_require__(3764);
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2159,7 +2159,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 3136:
+/***/ 917:
 /***/ (function(module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2181,8 +2181,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const semver = __importStar(__nccwpck_require__(7385));
-const core_1 = __nccwpck_require__(2619);
+const semver = __importStar(__nccwpck_require__(1892));
+const core_1 = __nccwpck_require__(3526);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __nccwpck_require__(2037);
@@ -2272,7 +2272,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 9471:
+/***/ 6849:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2294,7 +2294,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(2619));
+const core = __importStar(__nccwpck_require__(3526));
 /**
  * Internal class for retries
  */
@@ -2349,7 +2349,7 @@ exports.RetryHelper = RetryHelper;
 
 /***/ }),
 
-/***/ 8635:
+/***/ 370:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2374,20 +2374,20 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(2619));
-const io = __importStar(__nccwpck_require__(9006));
+const core = __importStar(__nccwpck_require__(3526));
+const io = __importStar(__nccwpck_require__(5998));
 const fs = __importStar(__nccwpck_require__(7147));
-const mm = __importStar(__nccwpck_require__(3136));
+const mm = __importStar(__nccwpck_require__(917));
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
-const httpm = __importStar(__nccwpck_require__(1709));
-const semver = __importStar(__nccwpck_require__(7385));
+const httpm = __importStar(__nccwpck_require__(1015));
+const semver = __importStar(__nccwpck_require__(1892));
 const stream = __importStar(__nccwpck_require__(2781));
 const util = __importStar(__nccwpck_require__(3837));
-const v4_1 = __importDefault(__nccwpck_require__(3581));
-const exec_1 = __nccwpck_require__(341);
+const v4_1 = __importDefault(__nccwpck_require__(6276));
+const exec_1 = __nccwpck_require__(4905);
 const assert_1 = __nccwpck_require__(9491);
-const retry_helper_1 = __nccwpck_require__(9471);
+const retry_helper_1 = __nccwpck_require__(6849);
 class HTTPError extends Error {
     constructor(httpStatusCode) {
         super(`Unexpected HTTP response: ${httpStatusCode}`);
@@ -2962,7 +2962,7 @@ function _unique(values) {
 
 /***/ }),
 
-/***/ 1938:
+/***/ 8095:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2970,10 +2970,10 @@ function _unique(values) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var core = __nccwpck_require__(8852);
-var authAction = __nccwpck_require__(9832);
-var pluginPaginateRest = __nccwpck_require__(293);
-var pluginRestEndpointMethods = __nccwpck_require__(1647);
+var core = __nccwpck_require__(5109);
+var authAction = __nccwpck_require__(135);
+var pluginPaginateRest = __nccwpck_require__(6152);
+var pluginRestEndpointMethods = __nccwpck_require__(6967);
 
 const VERSION = "3.7.1";
 
@@ -2994,7 +2994,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 9832:
+/***/ 135:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3002,7 +3002,7 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var authToken = __nccwpck_require__(9261);
+var authToken = __nccwpck_require__(549);
 
 const createActionAuth = function createActionAuth() {
   if (!process.env.GITHUB_ACTION) {
@@ -3029,7 +3029,7 @@ exports.createActionAuth = createActionAuth;
 
 /***/ }),
 
-/***/ 9261:
+/***/ 549:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3086,7 +3086,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 8852:
+/***/ 5109:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3094,11 +3094,11 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var universalUserAgent = __nccwpck_require__(4757);
-var beforeAfterHook = __nccwpck_require__(7150);
-var request = __nccwpck_require__(2751);
-var graphql = __nccwpck_require__(7613);
-var authToken = __nccwpck_require__(9261);
+var universalUserAgent = __nccwpck_require__(4947);
+var beforeAfterHook = __nccwpck_require__(3305);
+var request = __nccwpck_require__(4227);
+var graphql = __nccwpck_require__(8246);
+var authToken = __nccwpck_require__(549);
 
 function _objectWithoutPropertiesLoose(source, excluded) {
   if (source == null) return {};
@@ -3269,7 +3269,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 3017:
+/***/ 4258:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3277,8 +3277,8 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __nccwpck_require__(8875);
-var universalUserAgent = __nccwpck_require__(4757);
+var isPlainObject = __nccwpck_require__(2813);
+var universalUserAgent = __nccwpck_require__(4947);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -3667,7 +3667,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 7613:
+/***/ 8246:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3675,8 +3675,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(2751);
-var universalUserAgent = __nccwpck_require__(4757);
+var request = __nccwpck_require__(4227);
+var universalUserAgent = __nccwpck_require__(4947);
 
 const VERSION = "4.6.1";
 
@@ -3791,7 +3791,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 293:
+/***/ 6152:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3943,7 +3943,7 @@ exports.paginatingEndpoints = paginatingEndpoints;
 
 /***/ }),
 
-/***/ 1647:
+/***/ 6967:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5188,7 +5188,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 8902:
+/***/ 3242:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5198,8 +5198,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(5675);
-var once = _interopDefault(__nccwpck_require__(2654));
+var deprecation = __nccwpck_require__(6275);
+var once = _interopDefault(__nccwpck_require__(2520));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -5251,7 +5251,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 2751:
+/***/ 4227:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5261,11 +5261,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(3017);
-var universalUserAgent = __nccwpck_require__(4757);
-var isPlainObject = __nccwpck_require__(8875);
-var nodeFetch = _interopDefault(__nccwpck_require__(5401));
-var requestError = __nccwpck_require__(8902);
+var endpoint = __nccwpck_require__(4258);
+var universalUserAgent = __nccwpck_require__(4947);
+var isPlainObject = __nccwpck_require__(2813);
+var nodeFetch = _interopDefault(__nccwpck_require__(5868));
+var requestError = __nccwpck_require__(3242);
 
 const VERSION = "5.4.15";
 
@@ -5409,12 +5409,12 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 7150:
+/***/ 3305:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(5506)
-var addHook = __nccwpck_require__(8637)
-var removeHook = __nccwpck_require__(4335)
+var register = __nccwpck_require__(6345)
+var addHook = __nccwpck_require__(9204)
+var removeHook = __nccwpck_require__(5388)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -5473,7 +5473,7 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 
-/***/ 8637:
+/***/ 9204:
 /***/ ((module) => {
 
 module.exports = addHook;
@@ -5526,7 +5526,7 @@ function addHook(state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 5506:
+/***/ 6345:
 /***/ ((module) => {
 
 module.exports = register;
@@ -5560,7 +5560,7 @@ function register(state, name, method, options) {
 
 /***/ }),
 
-/***/ 4335:
+/***/ 5388:
 /***/ ((module) => {
 
 module.exports = removeHook;
@@ -5586,7 +5586,7 @@ function removeHook(state, name, method) {
 
 /***/ }),
 
-/***/ 5675:
+/***/ 6275:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5614,7 +5614,7 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 8875:
+/***/ 2813:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5660,7 +5660,7 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 5401:
+/***/ 5868:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5825,7 +5825,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = (__nccwpck_require__(7254).convert);
+	convert = (__nccwpck_require__(9165).convert);
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -7317,10 +7317,10 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 2654:
+/***/ 2520:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(1999)
+var wrappy = __nccwpck_require__(7449)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -7366,7 +7366,7 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 7385:
+/***/ 1892:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -8969,15 +8969,15 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 6237:
+/***/ 9622:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(2576);
+module.exports = __nccwpck_require__(9837);
 
 
 /***/ }),
 
-/***/ 2576:
+/***/ 9837:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9249,7 +9249,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 4757:
+/***/ 4947:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -9275,7 +9275,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 362:
+/***/ 562:
 /***/ ((module) => {
 
 /**
@@ -9308,7 +9308,7 @@ module.exports = bytesToUuid;
 
 /***/ }),
 
-/***/ 5846:
+/***/ 2651:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Unique ID creation requires a high quality random # generator.  In node.js
@@ -9323,11 +9323,11 @@ module.exports = function nodeRNG() {
 
 /***/ }),
 
-/***/ 3581:
+/***/ 6276:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var rng = __nccwpck_require__(5846);
-var bytesToUuid = __nccwpck_require__(362);
+var rng = __nccwpck_require__(2651);
+var bytesToUuid = __nccwpck_require__(562);
 
 function v4(options, buf, offset) {
   var i = buf && offset || 0;
@@ -9359,7 +9359,7 @@ module.exports = v4;
 
 /***/ }),
 
-/***/ 1999:
+/***/ 7449:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -9399,7 +9399,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 5557:
+/***/ 8662:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -9434,13 +9434,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getGraalVM = void 0;
-const core = __importStar(__nccwpck_require__(2619));
-const io = __importStar(__nccwpck_require__(9006));
-const exec = __importStar(__nccwpck_require__(341));
-const tc = __importStar(__nccwpck_require__(8635));
+const core = __importStar(__nccwpck_require__(3526));
+const io = __importStar(__nccwpck_require__(5998));
+const exec = __importStar(__nccwpck_require__(4905));
+const tc = __importStar(__nccwpck_require__(370));
 const fs = __importStar(__nccwpck_require__(7147));
 const path = __importStar(__nccwpck_require__(1017));
-const action_1 = __nccwpck_require__(1938);
+const action_1 = __nccwpck_require__(8095);
 let tempDirectory = process.env['RUNNER_TEMP'] || '';
 const IS_WINDOWS = process.platform === 'win32';
 const IS_DARWIN = process.platform === 'darwin';
@@ -9495,17 +9495,27 @@ function getGraalVM(graalvm, jdk, arch) {
         else {
             let java = ``;
             let m1 = ``;
-            if (jdk == 'java17' || jdk == 'java11') {
+            if (jdk == 'java23') {
                 java = `-${jdk}`;
+                m1 = `amd64`;
                 if (arch == 'aarch64') {
-                    m1 = `-m1`;
+                    m1 = `aarch64`;
                 }
+            }
+            else if (jdk == 'java17' || jdk == 'java11') {
+                java = `svm-${jdk}`;
+                if (arch == 'aarch64') {
+                    m1 = `m1`;
+                }
+            }
+            else {
+                java = `svm`;
             }
             let ext = 'tar.gz';
             if (IS_WINDOWS || graalvmShort.startsWith('gluon-22.0') || graalvmShort.startsWith('gluon-21')) {
                 ext = 'zip';
             }
-            const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-svm${java}-${platform}${m1}-${graalvmShort}.${ext}`;
+            const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-${java}-${platform}-${m1}-${graalvmShort}.${ext}`;
             core.info(`Downloading Gluon's GraalVM from ${downloadPath}`);
             const graalvmFile = yield tc.downloadTool(downloadPath);
             const tempDir = path.join(tempDirectory, `temp_${Math.floor(Math.random() * 2000000000)}`);
@@ -9594,7 +9604,7 @@ function unpackGraalVMDownload(repoRoot, destinationFolder) {
 
 /***/ }),
 
-/***/ 2039:
+/***/ 4717:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -9628,8 +9638,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(2619));
-const installer = __importStar(__nccwpck_require__(5557));
+const core = __importStar(__nccwpck_require__(3526));
+const installer = __importStar(__nccwpck_require__(8662));
 const path = __importStar(__nccwpck_require__(1017));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -9651,7 +9661,7 @@ run();
 
 /***/ }),
 
-/***/ 7254:
+/***/ 9165:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -9821,7 +9831,7 @@ module.exports = require("zlib");
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(2039);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(4717);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -67,14 +67,14 @@ export async function getGraalVM(
     let m1 = ``
     if (jdk == 'java23') {
       java = `-${jdk}`
-      m1 = `amd64`
+      m1 = `-amd64`
       if (arch == 'aarch64') {
-        m1 = `aarch64`
+        m1 = `-aarch64`
       }
     } else if (jdk == 'java17' || jdk == 'java11') {
       java = `svm-${jdk}`
       if (arch == 'aarch64') {
-        m1 = `m1`
+        m1 = `-m1`
       }
     } else {
       java = `svm`
@@ -83,7 +83,7 @@ export async function getGraalVM(
     if (IS_WINDOWS || graalvmShort.startsWith('gluon-22.0') || graalvmShort.startsWith('gluon-21')) {
       ext = 'zip'
     }
-    const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-${java}-${platform}-${m1}-${graalvmShort}.${ext}`
+    const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-${java}-${platform}${m1}-${graalvmShort}.${ext}`
 
     core.info(`Downloading Gluon's GraalVM from ${downloadPath}`)
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -65,17 +65,25 @@ export async function getGraalVM(
   } else {
     let java = ``
     let m1 = ``
-    if (jdk == 'java17' || jdk == 'java11') {
+    if (jdk == 'java23') {
       java = `-${jdk}`
+      m1 = `amd64`
       if (arch == 'aarch64') {
-        m1 = `-m1`
+        m1 = `aarch64`
       }
+    } else if (jdk == 'java17' || jdk == 'java11') {
+      java = `svm-${jdk}`
+      if (arch == 'aarch64') {
+        m1 = `m1`
+      }
+    } else {
+      java = `svm`
     }
     let ext = 'tar.gz'
     if (IS_WINDOWS || graalvmShort.startsWith('gluon-22.0') || graalvmShort.startsWith('gluon-21')) {
       ext = 'zip'
     }
-    const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-svm${java}-${platform}${m1}-${graalvmShort}.${ext}`
+    const downloadPath = `https://github.com/gluonhq/graal/releases/download/${version}/graalvm-${java}-${platform}-${m1}-${graalvmShort}.${ext}`
 
     core.info(`Downloading Gluon's GraalVM from ${downloadPath}`)
 


### PR DESCRIPTION
Update required to retrieve latest Gluon GraalVM builds (like https://github.com/gluonhq/graal/releases/tag/gluon-23%2B25.1-dev-240903-1155)